### PR TITLE
Div by zero and reformatting

### DIFF
--- a/Example/MMSpreadsheetView/MMAppDelegate.m
+++ b/Example/MMSpreadsheetView/MMAppDelegate.m
@@ -24,12 +24,25 @@
 
 @implementation MMAppDelegate
 
-- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
+{
     self.window = [[UIWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
     // Override point for customization after application launch.
     self.viewController = [[MMViewController alloc] init];
     self.window.rootViewController = self.viewController;
     [self.window makeKeyAndVisible];
+    return YES;
+}
+
+#pragma mark - state restoration
+
+- (BOOL)application:(UIApplication *)application shouldSaveApplicationState:(NSCoder *)coder
+{
+    return YES;
+}
+
+- (BOOL)application:(UIApplication *)application shouldRestoreApplicationState:(NSCoder *)coder
+{
     return YES;
 }
 

--- a/Example/MMSpreadsheetView/MMGridCell.m
+++ b/Example/MMSpreadsheetView/MMGridCell.m
@@ -22,7 +22,8 @@
 
 @implementation MMGridCell
 
-- (id)initWithFrame:(CGRect)frame {
+- (id)initWithFrame:(CGRect)frame
+{
     self = [super initWithFrame:frame];
     if (self) {
         CGRect rect = CGRectMake(0.0f, 0.0f, frame.size.width, frame.size.height);
@@ -35,7 +36,8 @@
     return self;
 }
 
-- (void)setSelected:(BOOL)selected {
+- (void)setSelected:(BOOL)selected
+{
     [super setSelected:selected];
     if (selected) {
         [self.contentView setBackgroundColor:[UIColor lightGrayColor]];

--- a/Example/MMSpreadsheetView/MMLeftColumnCell.m
+++ b/Example/MMSpreadsheetView/MMLeftColumnCell.m
@@ -22,7 +22,8 @@
 
 @implementation MMLeftColumnCell
 
-- (id)initWithFrame:(CGRect)frame {
+- (id)initWithFrame:(CGRect)frame
+{
     self = [super initWithFrame:frame];
     if (self) {
         CGRect rect = CGRectMake(20.0f, 0.0f, frame.size.width-40.0f, frame.size.height);

--- a/Example/MMSpreadsheetView/MMTopRowCell.m
+++ b/Example/MMSpreadsheetView/MMTopRowCell.m
@@ -22,7 +22,8 @@
 
 @implementation MMTopRowCell
 
-- (id)initWithFrame:(CGRect)frame {
+- (id)initWithFrame:(CGRect)frame
+{
     self = [super initWithFrame:frame];
     if (self) {
         CGRect rect = CGRectMake(0.0f, 0.0f, frame.size.width, frame.size.height);

--- a/Example/MMSpreadsheetView/MMViewController.m
+++ b/Example/MMSpreadsheetView/MMViewController.m
@@ -35,7 +35,8 @@
 
 @implementation MMViewController
 
-- (void)viewDidLoad {
+- (void)viewDidLoad
+{
     [super viewDidLoad];
     
     NSUInteger rows = 11;
@@ -47,7 +48,7 @@
     for (NSUInteger rowNumber = 0; rowNumber < rows; rowNumber++) {
         NSMutableArray *row = [NSMutableArray array];
         for (NSUInteger columnNumber = 0; columnNumber < cols; columnNumber++) {
-            [row addObject:[NSString stringWithFormat:@"R%i:C%i", rowNumber, columnNumber]];
+            [row addObject:[NSString stringWithFormat:@"R%lu:C%lu", (unsigned long)rowNumber, (unsigned long)columnNumber]];
         }
         [self.tableData addObject:row];
     }
@@ -56,6 +57,8 @@
 
     // Create the spreadsheet in code.
     MMSpreadsheetView *spreadSheetView = [[MMSpreadsheetView alloc] initWithNumberOfHeaderRows:1 numberOfHeaderColumns:1 frame:self.view.bounds];
+    self.restorationIdentifier = NSStringFromClass([self class]);
+    spreadSheetView.restorationIdentifier = @"MMSpreadsheetView";
 
     // Register your cell classes.
     [spreadSheetView registerCellClass:[MMGridCell class] forCellWithReuseIdentifier:@"GridCell"];
@@ -65,19 +68,22 @@
     // Set the delegate & datasource for the spreadsheet view.
     spreadSheetView.delegate = self;
     spreadSheetView.dataSource = self;
+    spreadSheetView.bounces = NO;
     
     // Add the spreadsheet view as a subview.
     [self.view addSubview:spreadSheetView];
 }
 
-- (void)didReceiveMemoryWarning {
+- (void)didReceiveMemoryWarning
+{
     [super didReceiveMemoryWarning];
     // Dispose of any resources that can be recreated.
 }
 
 #pragma mark - MMSpreadsheetViewDataSource
 
-- (CGSize)spreadsheetView:(MMSpreadsheetView *)spreadsheetView sizeForItemAtIndexPath:(NSIndexPath *)indexPath {
+- (CGSize)spreadsheetView:(MMSpreadsheetView *)spreadsheetView sizeForItemAtIndexPath:(NSIndexPath *)indexPath
+{
     CGFloat leftColumnWidth = 320.0f;
     CGFloat topRowHeight = 150.0f;
     CGFloat gridCellWidth = 124.0f;
@@ -101,18 +107,21 @@
     return CGSizeMake(gridCellWidth, gridCellHeight);
 }
 
-- (NSInteger)numberOfRowsInSpreadsheetView:(MMSpreadsheetView *)spreadsheetView {
+- (NSInteger)numberOfRowsInSpreadsheetView:(MMSpreadsheetView *)spreadsheetView
+{
     NSInteger rows = [self.tableData count];
     return rows;
 }
 
-- (NSInteger)numberOfColumnsInSpreadsheetView:(MMSpreadsheetView *)spreadsheetView {
+- (NSInteger)numberOfColumnsInSpreadsheetView:(MMSpreadsheetView *)spreadsheetView
+{
     NSArray *rowData = [self.tableData lastObject];
     NSInteger cols = [rowData count];
     return cols;
 }
 
-- (UICollectionViewCell *)spreadsheetView:(MMSpreadsheetView *)spreadsheetView cellForItemAtIndexPath:(NSIndexPath *)indexPath {
+- (UICollectionViewCell *)spreadsheetView:(MMSpreadsheetView *)spreadsheetView cellForItemAtIndexPath:(NSIndexPath *)indexPath
+{
     UICollectionViewCell *cell = nil;
     if (indexPath.mmSpreadsheetRow == 0 && indexPath.mmSpreadsheetColumn == 0) {
         // Upper left.
@@ -128,14 +137,14 @@
         // Upper right.
         cell = [spreadsheetView dequeueReusableCellWithReuseIdentifier:@"TopRowCell" forIndexPath:indexPath];
         MMTopRowCell *tr = (MMTopRowCell *)cell;
-        tr.textLabel.text = [NSString stringWithFormat:@"TR: %i", indexPath.mmSpreadsheetColumn];
+        tr.textLabel.text = [NSString stringWithFormat:@"TR: %li", (long)indexPath.mmSpreadsheetColumn];
         cell.backgroundColor = [UIColor whiteColor];
     }
     else if (indexPath.mmSpreadsheetRow > 0 && indexPath.mmSpreadsheetColumn == 0) {
         // Lower left.
         cell = [spreadsheetView dequeueReusableCellWithReuseIdentifier:@"LeftColumnCell" forIndexPath:indexPath];
         MMLeftColumnCell *lc = (MMLeftColumnCell *)cell;
-        lc.textLabel.text = [NSString stringWithFormat:@"Left Column: %i", indexPath.mmSpreadsheetRow];
+        lc.textLabel.text = [NSString stringWithFormat:@"Left Column: %li", (long)indexPath.mmSpreadsheetRow];
         BOOL isDarker = indexPath.mmSpreadsheetRow % 2 == 0;
         if (isDarker) {
             cell.backgroundColor = [UIColor colorWithRed:222.0f / 255.0f green:243.0f / 255.0f blue:250.0f / 255.0f alpha:1.0f];
@@ -163,7 +172,8 @@
 
 #pragma mark - MMSpreadsheetViewDelegate
 
-- (void)spreadsheetView:(MMSpreadsheetView *)spreadsheetView didSelectItemAtIndexPath:(NSIndexPath *)indexPath {
+- (void)spreadsheetView:(MMSpreadsheetView *)spreadsheetView didSelectItemAtIndexPath:(NSIndexPath *)indexPath
+{
     if ([self.selectedGridCells containsObject:indexPath]) {
         [self.selectedGridCells removeObject:indexPath];
         [spreadsheetView deselectItemAtIndexPath:indexPath animated:YES];
@@ -173,11 +183,13 @@
     }
 }
 
-- (BOOL)spreadsheetView:(MMSpreadsheetView *)spreadsheetView shouldShowMenuForItemAtIndexPath:(NSIndexPath *)indexPath {
+- (BOOL)spreadsheetView:(MMSpreadsheetView *)spreadsheetView shouldShowMenuForItemAtIndexPath:(NSIndexPath *)indexPath
+{
     return YES;
 }
 
-- (BOOL)spreadsheetView:(MMSpreadsheetView *)spreadsheetView canPerformAction:(SEL)action forItemAtIndexPath:(NSIndexPath *)indexPath withSender:(id)sender {
+- (BOOL)spreadsheetView:(MMSpreadsheetView *)spreadsheetView canPerformAction:(SEL)action forItemAtIndexPath:(NSIndexPath *)indexPath withSender:(id)sender
+{
     
     /*
      These are the selectors the sender (a UIMenuController) sends by default.
@@ -209,7 +221,8 @@
     return NO;
 }
 
-- (void)spreadsheetView:(MMSpreadsheetView *)spreadsheetView performAction:(SEL)action forItemAtIndexPath:(NSIndexPath *)indexPath withSender:(id)sender {
+- (void)spreadsheetView:(MMSpreadsheetView *)spreadsheetView performAction:(SEL)action forItemAtIndexPath:(NSIndexPath *)indexPath withSender:(id)sender
+{
     NSMutableArray *rowData = [self.tableData objectAtIndex:indexPath.mmSpreadsheetRow];
     if (action == @selector(cut:)) {
         self.cellDataBuffer = [rowData objectAtIndex:indexPath.row];

--- a/MMSpreadsheetView.podspec
+++ b/MMSpreadsheetView.podspec
@@ -5,7 +5,7 @@ Pod::Spec.new do |s|
   s.homepage     = "https://github.com/mutualmobile/MMSpreadsheetView"
   s.license      = { :type => 'MIT', :file => 'LICENSE' }
   s.author       = { "Jeff Lacey" => "jeff.lacey@mutualmobile.com" }
-  s.source       = { :git => "https://github.com/mutualmobile/MMSpreadsheetView.git", :tag => "0.0.3" }
+  s.source       = { :git => "https://github.com/mutualmobile/MMSpreadsheetView.git", :tag => s.version.to_s }
   s.platform     = :ios, '6.0'
   s.requires_arc = true
   s.source_files = 'MMSpreadsheetView/*.{h,m}'

--- a/MMSpreadsheetView/MMGridLayout.m
+++ b/MMSpreadsheetView/MMGridLayout.m
@@ -31,7 +31,8 @@
 
 @implementation MMGridLayout
 
-- (id)init {
+- (instancetype)init
+{
     self = [super init];
     if (self) {
         _cellSpacing = 1.0f;
@@ -40,17 +41,20 @@
     return self;
 }
 
-- (void)setItemSize:(CGSize)itemSize {
+- (void)setItemSize:(CGSize)itemSize
+{
     _itemSize = CGSizeMake(itemSize.width + self.cellSpacing, itemSize.height + self.cellSpacing);
     [self invalidateLayout];
 }
 
-- (void)setCellSpacing:(CGFloat)cellSpacing {
+- (void)setCellSpacing:(CGFloat)cellSpacing
+{
     _cellSpacing = cellSpacing;
     [self invalidateLayout];
 }
 
-- (void)prepareLayout {
+- (void)prepareLayout
+{
     [super prepareLayout];
     self.gridRowCount = [self.collectionView numberOfSections];
     self.gridColumnCount = [self.collectionView numberOfItemsInSection:0];
@@ -65,7 +69,8 @@
     }
 }
 
-- (CGSize)collectionViewContentSize {
+- (CGSize)collectionViewContentSize
+{
     if (!self.isInitialized) {
         [self prepareLayout];
     }
@@ -73,7 +78,8 @@
     return size;
 }
 
-- (NSArray *)layoutAttributesForElementsInRect:(CGRect)rect {
+- (NSArray *)layoutAttributesForElementsInRect:(CGRect)rect
+{
     NSMutableArray *attributes = [NSMutableArray array];
     NSUInteger startRow = floorf(rect.origin.y / self.itemSize.height);
     NSUInteger startCol = floorf(rect.origin.x / self.itemSize.width);
@@ -92,13 +98,15 @@
     return attributes;
 }
 
-- (UICollectionViewLayoutAttributes *)layoutAttributesForItemAtIndexPath:(NSIndexPath *)indexPath {
+- (UICollectionViewLayoutAttributes *)layoutAttributesForItemAtIndexPath:(NSIndexPath *)indexPath
+{
     UICollectionViewLayoutAttributes *attributes = [UICollectionViewLayoutAttributes layoutAttributesForCellWithIndexPath:indexPath];
     attributes.frame = CGRectMake(indexPath.item * self.itemSize.width, indexPath.section * self.itemSize.height, self.itemSize.width-self.cellSpacing, self.itemSize.height-self.cellSpacing);
     return attributes;
 }
 
-- (BOOL)shouldInvalidateLayoutForBoundsChange:(CGRect)newBounds {
+- (BOOL)shouldInvalidateLayoutForBoundsChange:(CGRect)newBounds
+{
     return NO;
 }
 

--- a/MMSpreadsheetView/MMSpreadsheetView.h
+++ b/MMSpreadsheetView/MMSpreadsheetView.h
@@ -217,6 +217,14 @@
  */
 @property (nonatomic, weak) id<MMSpreadsheetViewDataSource> dataSource;
 
+/**
+ The identifier that determines whether the view supports state restoration.
+ 
+ @discussion This property indicates whether state information in the view should be preserved; it is also used to identify the view during the restoration process. The value of this property is nil by default, which indicates that the view’s state does not need to be saved. Assigning a string object to the property lets the owning view controller know that the view has relevant state information to save.
+ 
+ */
+@property (nonatomic, copy) NSString *restorationIdentifier;
+
 
 ///---------------------------------------
 /// @name Initializing & Setup

--- a/MMSpreadsheetView/MMSpreadsheetView.m
+++ b/MMSpreadsheetView/MMSpreadsheetView.m
@@ -23,14 +23,16 @@
 #import "MMGridLayout.h"
 #import "NSIndexPath+MMSpreadsheetView.h"
 
-typedef NS_ENUM(NSUInteger, MMSpreadsheetViewCollection) {
+typedef NS_ENUM(NSUInteger, MMSpreadsheetViewCollection)
+{
     MMSpreadsheetViewCollectionUpperLeft = 1,
     MMSpreadsheetViewCollectionUpperRight,
     MMSpreadsheetViewCollectionLowerLeft,
     MMSpreadsheetViewCollectionLowerRight,
 };
 
-typedef NS_ENUM(NSUInteger, MMSpreadsheetHeaderConfiguration) {
+typedef NS_ENUM(NSUInteger, MMSpreadsheetHeaderConfiguration)
+{
     MMSpreadsheetHeaderConfigurationNone = 0,
     MMSpreadsheetHeaderConfigurationColumnOnly,
     MMSpreadsheetHeaderConfigurationRowOnly,
@@ -76,17 +78,20 @@ const static NSUInteger MMScrollIndicatorTag = 12345;
 
 @implementation MMSpreadsheetView
 
-- (id)init {
+- (instancetype)init
+{
     return [self initWithNumberOfHeaderRows:0 numberOfHeaderColumns:0 frame:CGRectZero];
 }
 
-- (id)initWithFrame:(CGRect)frame {
+- (instancetype)initWithFrame:(CGRect)frame
+{
     return [self initWithNumberOfHeaderRows:0 numberOfHeaderColumns:0 frame:frame];
 }
 
 #pragma mark - MMSpreadsheetView designated initializer
 
-- (id)initWithNumberOfHeaderRows:(NSUInteger)headerRowCount numberOfHeaderColumns:(NSUInteger)headerColumnCount frame:(CGRect)frame {
+- (instancetype)initWithNumberOfHeaderRows:(NSUInteger)headerRowCount numberOfHeaderColumns:(NSUInteger)headerColumnCount frame:(CGRect)frame
+{
     self = [super initWithFrame:frame];
     if (self) {
         _scrollIndicatorInsets = UIEdgeInsetsZero;
@@ -116,7 +121,8 @@ const static NSUInteger MMScrollIndicatorTag = 12345;
 
 #pragma mark - Public Functions
 
-- (UICollectionViewCell *)dequeueReusableCellWithReuseIdentifier:identifier forIndexPath:(NSIndexPath *)indexPath {
+- (UICollectionViewCell *)dequeueReusableCellWithReuseIdentifier:identifier forIndexPath:(NSIndexPath *)indexPath
+{
     NSIndexPath *collectionViewIndexPath = [self collectionViewIndexPathFromDataSourceIndexPath:indexPath];
     UICollectionView *collectionView = [self collectionViewForDataSourceIndexPath:indexPath];
     NSAssert(collectionView, @"No collectionView Returned!");
@@ -125,35 +131,40 @@ const static NSUInteger MMScrollIndicatorTag = 12345;
     return cell;
 }
 
-- (void)registerCellClass:(Class)cellClass forCellWithReuseIdentifier:(NSString *)identifier {
+- (void)registerCellClass:(Class)cellClass forCellWithReuseIdentifier:(NSString *)identifier
+{
     [self.upperLeftCollectionView registerClass:cellClass forCellWithReuseIdentifier:identifier];
     [self.upperRightCollectionView registerClass:cellClass forCellWithReuseIdentifier:identifier];
     [self.lowerLeftCollectionView registerClass:cellClass forCellWithReuseIdentifier:identifier];
     [self.lowerRightCollectionView registerClass:cellClass forCellWithReuseIdentifier:identifier];
 }
 
-- (void)deselectItemAtIndexPath:(NSIndexPath *)indexPath animated:(BOOL)animated {
+- (void)deselectItemAtIndexPath:(NSIndexPath *)indexPath animated:(BOOL)animated
+{
     NSIndexPath *collectionViewIndexPath = [self collectionViewIndexPathFromDataSourceIndexPath:indexPath];
     UICollectionView *collectionView = [self collectionViewForDataSourceIndexPath:indexPath];
     NSAssert(collectionView, @"No collectionView Returned!");
     [collectionView deselectItemAtIndexPath:collectionViewIndexPath animated:animated];
 }
 
-- (void)reloadData {
+- (void)reloadData
+{
     [self.upperLeftCollectionView reloadData];
     [self.upperRightCollectionView reloadData];
     [self.lowerLeftCollectionView reloadData];
     [self.lowerRightCollectionView reloadData];
 }
 
-- (void)flashScrollIndicators {
+- (void)flashScrollIndicators
+{
     [self showScrollIndicators];
     [self performSelector:@selector(hideScrollIndicators) withObject:nil afterDelay:1];
 }
 
 #pragma mark - View Setup functions
 
-- (void)setupSubviews {
+- (void)setupSubviews
+{
     switch (self.spreadsheetHeaderConfiguration) {
         case MMSpreadsheetHeaderConfigurationNone:
             [self setupLowerRightView];
@@ -184,7 +195,8 @@ const static NSUInteger MMScrollIndicatorTag = 12345;
     self.horizontalScrollIndicator = [self setupScrollIndicator];
 }
 
-- (void)setupContainerSubview:(UIView *)container collectionView:(UICollectionView *)collectionView tag:(NSInteger)tag {
+- (void)setupContainerSubview:(UIView *)container collectionView:(UICollectionView *)collectionView tag:(NSInteger)tag
+{
     container.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
     [self addSubview:container];
     
@@ -198,13 +210,15 @@ const static NSUInteger MMScrollIndicatorTag = 12345;
     [container addSubview:collectionView];
 }
 
-- (UICollectionView *)setupCollectionViewWithGridLayout {
+- (UICollectionView *)setupCollectionViewWithGridLayout
+{
     MMGridLayout *layout = [[MMGridLayout alloc] init];
     UICollectionView *collectionView = [[UICollectionView alloc] initWithFrame:CGRectZero collectionViewLayout:layout];
     return collectionView;
 }
 
-- (void)setupUpperLeftView {
+- (void)setupUpperLeftView
+{
     self.upperLeftContainerView = [[UIView alloc] initWithFrame:CGRectZero];
     self.upperLeftCollectionView = [self setupCollectionViewWithGridLayout];
     [self setupContainerSubview:self.upperLeftContainerView
@@ -213,7 +227,8 @@ const static NSUInteger MMScrollIndicatorTag = 12345;
     self.upperLeftCollectionView.scrollEnabled = NO;
 }
 
-- (void)setupUpperRightView {
+- (void)setupUpperRightView
+{
     self.upperRightContainerView = [[UIView alloc] initWithFrame:CGRectZero];
     self.upperRightCollectionView = [self setupCollectionViewWithGridLayout];
     [self.upperRightCollectionView.panGestureRecognizer addTarget:self
@@ -223,7 +238,8 @@ const static NSUInteger MMScrollIndicatorTag = 12345;
                             tag:MMSpreadsheetViewCollectionUpperRight];
 }
 
-- (void)setupLowerLeftView {
+- (void)setupLowerLeftView
+{
     self.lowerLeftContainerView = [[UIView alloc] initWithFrame:CGRectZero];
     self.lowerLeftCollectionView = [self setupCollectionViewWithGridLayout];
     [self.lowerLeftCollectionView.panGestureRecognizer addTarget:self
@@ -233,7 +249,8 @@ const static NSUInteger MMScrollIndicatorTag = 12345;
                             tag:MMSpreadsheetViewCollectionLowerLeft];
 }
 
-- (void)setupLowerRightView {
+- (void)setupLowerRightView
+{
     self.lowerRightContainerView = [[UIView alloc] initWithFrame:CGRectZero];
     self.lowerRightCollectionView = [self setupCollectionViewWithGridLayout];
     [self.lowerRightCollectionView.panGestureRecognizer addTarget:self
@@ -243,7 +260,8 @@ const static NSUInteger MMScrollIndicatorTag = 12345;
                             tag:MMSpreadsheetViewCollectionLowerRight];
 }
 
-- (void)layoutSubviews {
+- (void)layoutSubviews
+{
     [super layoutSubviews];
     NSIndexPath *indexPathZero = [NSIndexPath indexPathForItem:0 inSection:0];
     switch (self.spreadsheetHeaderConfiguration) {
@@ -345,7 +363,8 @@ const static NSUInteger MMScrollIndicatorTag = 12345;
 
 #pragma mark - UIPanGestureRecognizer callbacks
 
-- (void)handleUpperRightPanGesture:(UIPanGestureRecognizer *)recognizer {
+- (void)handleUpperRightPanGesture:(UIPanGestureRecognizer *)recognizer
+{
     if (recognizer.state == UIGestureRecognizerStateBegan) {
         self.lowerLeftContainerView.userInteractionEnabled = NO;
         self.lowerRightContainerView.userInteractionEnabled = NO;
@@ -358,7 +377,8 @@ const static NSUInteger MMScrollIndicatorTag = 12345;
     }
 }
 
-- (void)handleLowerLeftPanGesture:(UIPanGestureRecognizer *)recognizer {
+- (void)handleLowerLeftPanGesture:(UIPanGestureRecognizer *)recognizer
+{
     if (recognizer.state == UIGestureRecognizerStateBegan) {
         self.upperRightContainerView.userInteractionEnabled = NO;
         self.lowerRightContainerView.userInteractionEnabled = NO;
@@ -371,7 +391,8 @@ const static NSUInteger MMScrollIndicatorTag = 12345;
     }
 }
 
-- (void)handleLowerRightPanGesture:(UIPanGestureRecognizer *)recognizer {
+- (void)handleLowerRightPanGesture:(UIPanGestureRecognizer *)recognizer
+{
     if (recognizer.state == UIGestureRecognizerStateBegan) {
         self.upperRightContainerView.userInteractionEnabled = NO;
         self.lowerLeftContainerView.userInteractionEnabled = NO;
@@ -384,9 +405,18 @@ const static NSUInteger MMScrollIndicatorTag = 12345;
     }
 }
 
-#pragma mark - bounces property setter
+#pragma mark - property setters
 
-- (void)setBounces:(BOOL)bounces {
+- (void)setRestorationIdentifier:(NSString *)restorationIdentifier
+{
+    _restorationIdentifier = [restorationIdentifier copy];
+    self.upperRightCollectionView.restorationIdentifier = [NSString stringWithFormat:@"%@-upperRightCollectionView", restorationIdentifier];
+    self.lowerLeftCollectionView.restorationIdentifier = [NSString stringWithFormat:@"%@-lowerLeftCollectionView", restorationIdentifier];
+    self.lowerRightCollectionView.restorationIdentifier = [NSString stringWithFormat:@"%@-lowerRightCollectionView", restorationIdentifier];
+}
+
+- (void)setBounces:(BOOL)bounces
+{
     _bounces = bounces;
     self.upperLeftCollectionView.bounces = bounces;
     self.upperRightCollectionView.bounces = bounces;
@@ -394,9 +424,8 @@ const static NSUInteger MMScrollIndicatorTag = 12345;
     self.lowerRightCollectionView.bounces = bounces;
 }
 
-#pragma mark - DataSource property setter
-
-- (void)setDataSource:(id<MMSpreadsheetViewDataSource>)dataSource {
+- (void)setDataSource:(id<MMSpreadsheetViewDataSource>)dataSource
+{
     _dataSource = dataSource;
     if (self.upperLeftCollectionView) {
         [self initializeCollectionViewLayoutItemSize:self.upperLeftCollectionView];
@@ -419,7 +448,8 @@ const static NSUInteger MMScrollIndicatorTag = 12345;
     NSAssert(self.headerRowCount < maxRows, @"Invalid configuration: number of header rows must be less than (dataSource) numberOfRowsInSpreadsheetView");
 }
 
-- (void)initializeCollectionViewLayoutItemSize:(UICollectionView *)collectionView {
+- (void)initializeCollectionViewLayoutItemSize:(UICollectionView *)collectionView
+{
     NSIndexPath *indexPathZero = [NSIndexPath indexPathForItem:0 inSection:0];
     MMGridLayout *layout = (MMGridLayout *)collectionView.collectionViewLayout;
     CGSize size = [self collectionView:collectionView
@@ -430,7 +460,8 @@ const static NSUInteger MMScrollIndicatorTag = 12345;
 
 #pragma mark - Scroll Indicator
 
-- (UIView *)setupScrollIndicator {
+- (UIView *)setupScrollIndicator
+{
     UIView *scrollIndicator = [[UIView alloc] initWithFrame:CGRectZero];
     scrollIndicator.alpha = 0.0f;
     scrollIndicator.layer.cornerRadius = MMSpreadsheetViewScrollIndicatorWidth/2;
@@ -446,7 +477,8 @@ const static NSUInteger MMScrollIndicatorTag = 12345;
     return scrollIndicator;
 }
 
-- (void)showScrollIndicators {
+- (void)showScrollIndicators
+{
     [NSObject cancelPreviousPerformRequestsWithTarget:self selector:_cmd object:nil];
     [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(hideScrollIndicators) object:nil];
     [UIView animateWithDuration:0.4f animations:^{
@@ -455,7 +487,8 @@ const static NSUInteger MMScrollIndicatorTag = 12345;
     }];
 }
 
-- (void)hideScrollIndicators {
+- (void)hideScrollIndicators
+{
     [NSObject cancelPreviousPerformRequestsWithTarget:self selector:_cmd object:nil];
     [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(showScrollIndicators) object:nil];
     [UIView animateWithDuration:0.5f animations:^{
@@ -464,7 +497,8 @@ const static NSUInteger MMScrollIndicatorTag = 12345;
     }];
 }
 
-- (void)updateVerticalScrollIndicator {
+- (void)updateVerticalScrollIndicator
+{
     if (self.showsVerticalScrollIndicator) {
         UIView *scrollIndicator = self.verticalScrollIndicator;
         UIView *indicatorView = [scrollIndicator viewWithTag:MMScrollIndicatorTag];
@@ -488,7 +522,8 @@ const static NSUInteger MMScrollIndicatorTag = 12345;
     }
 }
 
-- (void)updateHorizontalScrollIndicator {
+- (void)updateHorizontalScrollIndicator
+{
     if (self.showsHorizontalScrollIndicator) {
         UIView *scrollIndicator = self.horizontalScrollIndicator;
         UIView *indicatorView = [scrollIndicator viewWithTag:MMScrollIndicatorTag];
@@ -503,7 +538,11 @@ const static NSUInteger MMScrollIndicatorTag = 12345;
             if (indicatorWidth < MMSpreadsheetViewScrollIndicatorMinimum) {
                 indicatorWidth = MMSpreadsheetViewScrollIndicatorMinimum;
             }
-            CGFloat indicatorOffsetX = collectionView.contentOffset.x / (contentSize.width - collectionViewFrame.size.width) * (scrollIndicator.frame.size.width-indicatorWidth);
+            CGFloat divZeroOffset = 0.0f;
+            if (contentSize.width == collectionViewFrame.size.width) {
+                divZeroOffset = 1.0f;
+            }
+            CGFloat indicatorOffsetX = collectionView.contentOffset.x / (contentSize.width - collectionViewFrame.size.width + divZeroOffset) * (scrollIndicator.frame.size.width-indicatorWidth);
             indicatorView.frame = CGRectMake(indicatorOffsetX,
                                              0.0f,
                                              indicatorWidth,
@@ -514,7 +553,8 @@ const static NSUInteger MMScrollIndicatorTag = 12345;
 
 #pragma mark - Custom functions that don't go anywhere else
 
-- (UICollectionView *)collectionViewForDataSourceIndexPath:(NSIndexPath *)indexPath {
+- (UICollectionView *)collectionViewForDataSourceIndexPath:(NSIndexPath *)indexPath
+{
     UICollectionView *collectionView = nil;
     switch (self.spreadsheetHeaderConfiguration) {
         case MMSpreadsheetHeaderConfigurationNone:
@@ -562,7 +602,8 @@ const static NSUInteger MMScrollIndicatorTag = 12345;
     return collectionView;
 }
 
-- (NSIndexPath *)dataSourceIndexPathFromCollectionView:(UICollectionView *)collectionView indexPath:(NSIndexPath *)indexPath {
+- (NSIndexPath *)dataSourceIndexPathFromCollectionView:(UICollectionView *)collectionView indexPath:(NSIndexPath *)indexPath
+{
     NSInteger mmSpreadsheetRow = indexPath.mmSpreadsheetRow;
     NSInteger mmSpreadsheetColumn = indexPath.mmSpreadsheetColumn;
 
@@ -592,7 +633,8 @@ const static NSUInteger MMScrollIndicatorTag = 12345;
     return [NSIndexPath indexPathForItem:mmSpreadsheetColumn inSection:mmSpreadsheetRow];
 }
 
-- (NSIndexPath *)collectionViewIndexPathFromDataSourceIndexPath:(NSIndexPath *)indexPath {
+- (NSIndexPath *)collectionViewIndexPathFromDataSourceIndexPath:(NSIndexPath *)indexPath
+{
     UICollectionView *collectionView = [self collectionViewForDataSourceIndexPath:indexPath];
     NSAssert(collectionView, @"No collectionView Returned!");
     
@@ -623,7 +665,8 @@ const static NSUInteger MMScrollIndicatorTag = 12345;
     return [NSIndexPath indexPathForItem:mmSpreadsheetColumn inSection:mmSpreadsheetRow];
 }
 
-- (void)setScrollEnabledValue:(BOOL)scrollEnabled scrollView:(UIScrollView *)scrollView {
+- (void)setScrollEnabledValue:(BOOL)scrollEnabled scrollView:(UIScrollView *)scrollView
+{
     switch (scrollView.tag) {
         case MMSpreadsheetViewCollectionUpperLeft:
             // Don't think we need to do anything here
@@ -648,7 +691,8 @@ const static NSUInteger MMScrollIndicatorTag = 12345;
 
 #pragma mark - UICollectionViewDelegateFlowLayout
 
-- (CGSize)collectionView:(UICollectionView *)collectionView layout:(UICollectionViewLayout *)collectionViewLayout sizeForItemAtIndexPath:(NSIndexPath *)indexPath {
+- (CGSize)collectionView:(UICollectionView *)collectionView layout:(UICollectionViewLayout *)collectionViewLayout sizeForItemAtIndexPath:(NSIndexPath *)indexPath
+{
     NSIndexPath *dataSourceIndexPath = [self dataSourceIndexPathFromCollectionView:collectionView indexPath:indexPath];
     CGSize size = [self.dataSource spreadsheetView:self sizeForItemAtIndexPath:dataSourceIndexPath];
     return size;
@@ -656,7 +700,8 @@ const static NSUInteger MMScrollIndicatorTag = 12345;
 
 #pragma mark - UICollectionViewDataSource pass-through
 
-- (NSInteger)numberOfSectionsInCollectionView:(UICollectionView *)collectionView {
+- (NSInteger)numberOfSectionsInCollectionView:(UICollectionView *)collectionView
+{
     NSInteger rowCount = [self.dataSource numberOfRowsInSpreadsheetView:self];
     NSInteger adjustedRows = 1;
     
@@ -685,7 +730,8 @@ const static NSUInteger MMScrollIndicatorTag = 12345;
     return adjustedRows;
 }
 
-- (NSInteger)collectionView:(UICollectionView *)collectionView numberOfItemsInSection:(NSInteger)section {
+- (NSInteger)collectionView:(UICollectionView *)collectionView numberOfItemsInSection:(NSInteger)section
+{
     NSInteger items = 0;
     NSInteger columnCount = [self.dataSource numberOfColumnsInSpreadsheetView:self];
     
@@ -714,7 +760,8 @@ const static NSUInteger MMScrollIndicatorTag = 12345;
     return items;
 }
 
-- (UICollectionViewCell *)collectionView:(UICollectionView *)collectionView cellForItemAtIndexPath:(NSIndexPath *)indexPath {
+- (UICollectionViewCell *)collectionView:(UICollectionView *)collectionView cellForItemAtIndexPath:(NSIndexPath *)indexPath
+{
     NSIndexPath *dataSourceIndexPath = [self dataSourceIndexPathFromCollectionView:collectionView indexPath:indexPath];
     UICollectionViewCell *cell = [self.dataSource spreadsheetView:self cellForItemAtIndexPath:dataSourceIndexPath];
     return cell;
@@ -722,7 +769,8 @@ const static NSUInteger MMScrollIndicatorTag = 12345;
 
 #pragma mark - UICollectionViewDelegate
 
-- (void)collectionView:(UICollectionView *)collectionView didSelectItemAtIndexPath:(NSIndexPath *)indexPath {
+- (void)collectionView:(UICollectionView *)collectionView didSelectItemAtIndexPath:(NSIndexPath *)indexPath
+{
     if (self.selectedItemCollectionView != nil) {
         if (collectionView == self.selectedItemCollectionView) {
             self.selectedItemIndexPath = indexPath;
@@ -742,7 +790,8 @@ const static NSUInteger MMScrollIndicatorTag = 12345;
     }
 }
 
-- (BOOL)collectionView:(UICollectionView *)collectionView shouldShowMenuForItemAtIndexPath:(NSIndexPath *)indexPath {
+- (BOOL)collectionView:(UICollectionView *)collectionView shouldShowMenuForItemAtIndexPath:(NSIndexPath *)indexPath
+{
     NSIndexPath *dataSourceIndexPath = [self dataSourceIndexPathFromCollectionView:collectionView indexPath:indexPath];
     if ([self.delegate respondsToSelector:@selector(spreadsheetView:shouldShowMenuForItemAtIndexPath:)]) {
         return [self.delegate spreadsheetView:self shouldShowMenuForItemAtIndexPath:dataSourceIndexPath];
@@ -750,7 +799,8 @@ const static NSUInteger MMScrollIndicatorTag = 12345;
     return NO;
 }
 
-- (BOOL)collectionView:(UICollectionView *)collectionView canPerformAction:(SEL)action forItemAtIndexPath:(NSIndexPath *)indexPath withSender:(id)sender {
+- (BOOL)collectionView:(UICollectionView *)collectionView canPerformAction:(SEL)action forItemAtIndexPath:(NSIndexPath *)indexPath withSender:(id)sender
+{
     NSIndexPath *dataSourceIndexPath = [self dataSourceIndexPathFromCollectionView:collectionView indexPath:indexPath];
     if ([self.delegate respondsToSelector:@selector(spreadsheetView:canPerformAction:forItemAtIndexPath:withSender:)]) {
         return [self.delegate spreadsheetView:self canPerformAction:action forItemAtIndexPath:dataSourceIndexPath withSender:sender];
@@ -758,7 +808,8 @@ const static NSUInteger MMScrollIndicatorTag = 12345;
     return NO;
 }
 
-- (void)collectionView:(UICollectionView *)collectionView performAction:(SEL)action forItemAtIndexPath:(NSIndexPath *)indexPath withSender:(id)sender {
+- (void)collectionView:(UICollectionView *)collectionView performAction:(SEL)action forItemAtIndexPath:(NSIndexPath *)indexPath withSender:(id)sender
+{
     NSIndexPath *dataSourceIndexPath = [self dataSourceIndexPathFromCollectionView:collectionView indexPath:indexPath];
     if ([self.delegate respondsToSelector:@selector(spreadsheetView:performAction:forItemAtIndexPath:withSender:)]) {
         return [self.delegate spreadsheetView:self performAction:action forItemAtIndexPath:dataSourceIndexPath withSender:sender];
@@ -767,7 +818,8 @@ const static NSUInteger MMScrollIndicatorTag = 12345;
 
 #pragma mark - UIScrollViewDelegate
 
-- (void)scrollViewDidScroll:(UIScrollView *)scrollView {
+- (void)scrollViewDidScroll:(UIScrollView *)scrollView
+{
     if (scrollView == self.controllingScrollView) {
     
         switch (scrollView.tag) {
@@ -788,7 +840,8 @@ const static NSUInteger MMScrollIndicatorTag = 12345;
     }
 }
 
-- (void)lowerLeftCollectionViewDidScrollForScrollView:(UIScrollView *)scrollView {
+- (void)lowerLeftCollectionViewDidScrollForScrollView:(UIScrollView *)scrollView
+{
     [self.lowerRightCollectionView setContentOffset:CGPointMake(self.lowerRightCollectionView.contentOffset.x, scrollView.contentOffset.y) animated:NO];
     [self updateVerticalScrollIndicator];
 
@@ -811,7 +864,8 @@ const static NSUInteger MMScrollIndicatorTag = 12345;
     }
 }
 
-- (void)upperRightCollectionViewDidScrollForScrollView:(UIScrollView *)scrollView {
+- (void)upperRightCollectionViewDidScrollForScrollView:(UIScrollView *)scrollView
+{
     [self.lowerRightCollectionView setContentOffset:CGPointMake(scrollView.contentOffset.x, self.lowerRightCollectionView.contentOffset.y) animated:NO];
     [self updateHorizontalScrollIndicator];
     
@@ -834,7 +888,8 @@ const static NSUInteger MMScrollIndicatorTag = 12345;
     }
 }
 
-- (void)lowerRightCollectionViewDidScrollForScrollView:(UIScrollView *)scrollView {
+- (void)lowerRightCollectionViewDidScrollForScrollView:(UIScrollView *)scrollView
+{
     [self updateVerticalScrollIndicator];
     [self updateHorizontalScrollIndicator];
 
@@ -880,7 +935,9 @@ const static NSUInteger MMScrollIndicatorTag = 12345;
     }
 }
 
-- (void)scrollViewWillBeginDragging:(UIScrollView *)scrollView {
+- (void)scrollViewWillBeginDragging:(UIScrollView *)scrollView
+{
+    NSLog(@"%s", __PRETTY_FUNCTION__);
     [self setScrollEnabledValue:NO scrollView:scrollView];
     
     if (self.controllingScrollView != scrollView) {
@@ -895,7 +952,9 @@ const static NSUInteger MMScrollIndicatorTag = 12345;
     [self setScrollEnabledValue:YES scrollView:scrollView];
 }
 
-- (void)scrollViewWillEndDragging:(UIScrollView *)scrollView withVelocity:(CGPoint)velocity targetContentOffset:(inout CGPoint *)targetContentOffset {
+- (void)scrollViewWillEndDragging:(UIScrollView *)scrollView withVelocity:(CGPoint)velocity targetContentOffset:(inout CGPoint *)targetContentOffset
+{
+    NSLog(@"%s VEL: %@", __PRETTY_FUNCTION__, NSStringFromCGPoint(velocity));
     // Block UI if we're in a bounce.
     // Without this, you can lock the scroll views in a scroll which looks weird.
     CGPoint toffset = *targetContentOffset;
@@ -903,7 +962,8 @@ const static NSUInteger MMScrollIndicatorTag = 12345;
         case MMSpreadsheetViewCollectionLowerLeft: {
             BOOL willBouncePastZeroY = velocity.y < 0.0f && !(toffset.y > 0.0f);
             BOOL willBouncePastMaxY = toffset.y > self.lowerLeftCollectionView.contentSize.height - self.lowerLeftCollectionView.frame.size.height - 0.1f && velocity.y > 0.0f;
-            if (willBouncePastZeroY || willBouncePastMaxY) {
+            if (willBouncePastZeroY || willBouncePastMaxY || !self.bounces) {
+                NSLog(@"LL scroll: UP & LR lockout");
                 self.upperRightContainerView.userInteractionEnabled = NO;
                 self.lowerRightContainerView.userInteractionEnabled = NO;
                 self.lowerLeftBouncing = YES;
@@ -914,7 +974,8 @@ const static NSUInteger MMScrollIndicatorTag = 12345;
         case MMSpreadsheetViewCollectionUpperRight: {
             BOOL willBouncePastZeroX = velocity.x < 0.0f && !(toffset.x > 0.0f);
             BOOL willBouncePastMaxX = toffset.x > self.upperRightCollectionView.contentSize.width - self.upperRightCollectionView.frame.size.width - 0.1f && velocity.x > 0.0f;
-            if (willBouncePastZeroX || willBouncePastMaxX) {
+            if (willBouncePastZeroX || willBouncePastMaxX || !self.bounces) {
+                NSLog(@"UR scroll: LL & LR lockout");
                 self.lowerRightContainerView.userInteractionEnabled = NO;
                 self.lowerLeftContainerView.userInteractionEnabled = NO;
                 self.upperRightBouncing = YES;
@@ -928,7 +989,8 @@ const static NSUInteger MMScrollIndicatorTag = 12345;
             BOOL willBouncePastZeroY = velocity.y < 0.0f && !(toffset.y > 0.0f);
             BOOL willBouncePastMaxY = toffset.y > self.lowerLeftCollectionView.contentSize.height - self.lowerLeftCollectionView.frame.size.height - 0.1f && velocity.y > 0.0f;
             if (willBouncePastZeroX || willBouncePastMaxX ||
-                willBouncePastZeroY || willBouncePastMaxY) {
+                willBouncePastZeroY || willBouncePastMaxY || !self.bounces) {
+                NSLog(@"LR scroll: UR & LL lockout");
                 self.upperRightContainerView.userInteractionEnabled = NO;
                 self.lowerLeftContainerView.userInteractionEnabled = NO;
                 self.lowerRightBouncing = YES;
@@ -938,11 +1000,14 @@ const static NSUInteger MMScrollIndicatorTag = 12345;
     }
 }
 
-- (void)scrollViewDidEndDecelerating:(UIScrollView *)scrollView {
+- (void)scrollViewDidEndDecelerating:(UIScrollView *)scrollView
+{
     [self scrollViewDidStop:scrollView];
 }
 
-- (void)scrollViewDidStop:(UIScrollView *)scrollView {
+- (void)scrollViewDidStop:(UIScrollView *)scrollView
+{
+    NSLog(@"%s", __PRETTY_FUNCTION__);
     self.upperRightContainerView.userInteractionEnabled = YES;
     self.lowerRightContainerView.userInteractionEnabled = YES;
     self.lowerLeftContainerView.userInteractionEnabled = YES;

--- a/MMSpreadsheetView/MMSpreadsheetView.m
+++ b/MMSpreadsheetView/MMSpreadsheetView.m
@@ -508,7 +508,8 @@ const static NSUInteger MMScrollIndicatorTag = 12345;
         
         if (collectionViewFrame.size.height > contentSize.height) {
             indicatorView.frame = CGRectZero;
-        } else {
+        }
+        else {
             CGFloat indicatorHeight = collectionViewFrame.size.height / contentSize.height * scrollIndicator.frame.size.height;
             if (indicatorHeight < MMSpreadsheetViewScrollIndicatorMinimum) {
                 indicatorHeight = MMSpreadsheetViewScrollIndicatorMinimum;
@@ -537,7 +538,8 @@ const static NSUInteger MMScrollIndicatorTag = 12345;
 
         if (collectionView.frame.size.width > contentSize.width) {
             indicatorView.frame = CGRectZero;
-        } else {
+        }
+        else {
             CGFloat indicatorWidth = collectionViewFrame.size.width/contentSize.width * scrollIndicator.frame.size.width;
             if (indicatorWidth < MMSpreadsheetViewScrollIndicatorMinimum) {
                 indicatorWidth = MMSpreadsheetViewScrollIndicatorMinimum;
@@ -568,7 +570,8 @@ const static NSUInteger MMScrollIndicatorTag = 12345;
         case MMSpreadsheetHeaderConfigurationColumnOnly:
             if (indexPath.mmSpreadsheetColumn >= self.headerColumnCount) {
                 collectionView = self.lowerRightCollectionView;
-            } else {
+            }
+            else {
                 collectionView = self.lowerLeftCollectionView;
             }
             break;
@@ -586,14 +589,16 @@ const static NSUInteger MMScrollIndicatorTag = 12345;
             if (indexPath.mmSpreadsheetRow >= self.headerRowCount) {
                 if (indexPath.mmSpreadsheetColumn >= self.headerColumnCount) {
                     collectionView = self.lowerRightCollectionView;
-                } else {
+                }
+                else {
                     collectionView = self.lowerLeftCollectionView;
                 }
             }
             else {
                 if (indexPath.mmSpreadsheetColumn >= self.headerColumnCount) {
                     collectionView = self.upperRightCollectionView;
-                } else {
+                }
+                else {
                     collectionView = self.upperLeftCollectionView;
                 }
             }
@@ -778,12 +783,14 @@ const static NSUInteger MMScrollIndicatorTag = 12345;
     if (self.selectedItemCollectionView != nil) {
         if (collectionView == self.selectedItemCollectionView) {
             self.selectedItemIndexPath = indexPath;
-        } else {
+        }
+        else {
             [self.selectedItemCollectionView deselectItemAtIndexPath:self.selectedItemIndexPath animated:NO];
             self.selectedItemCollectionView = collectionView;
             self.selectedItemIndexPath = indexPath;
         }
-    } else {
+    }
+    else {
         self.selectedItemCollectionView = collectionView;
         self.selectedItemIndexPath = indexPath;
     }
@@ -839,7 +846,8 @@ const static NSUInteger MMScrollIndicatorTag = 12345;
                 [self lowerRightCollectionViewDidScrollForScrollView:scrollView];
                 break;
         }
-    } else {
+    }
+    else {
         [scrollView setContentOffset:scrollView.contentOffset animated:NO];
     }
 }
@@ -857,7 +865,8 @@ const static NSUInteger MMScrollIndicatorTag = 12345;
         rect = self.upperRightContainerView.frame;
         rect.origin.y = 0-scrollView.contentOffset.y;
         self.upperRightContainerView.frame = rect;
-    } else {
+    }
+    else {
         CGRect rect = self.upperLeftContainerView.frame;
         rect.origin.y = 0.0f;
         self.upperLeftContainerView.frame = rect;
@@ -881,7 +890,8 @@ const static NSUInteger MMScrollIndicatorTag = 12345;
         rect = self.lowerLeftContainerView.frame;
         rect.origin.x = 0-scrollView.contentOffset.x;
         self.lowerLeftContainerView.frame = rect;
-    } else {
+    }
+    else {
         CGRect rect = self.upperLeftContainerView.frame;
         rect.origin.x = 0.0f;
         self.upperLeftContainerView.frame = rect;
@@ -910,7 +920,8 @@ const static NSUInteger MMScrollIndicatorTag = 12345;
         rect = self.upperRightContainerView.frame;
         rect.origin.y = 0-scrollView.contentOffset.y;
         self.upperRightContainerView.frame = rect;
-    } else {
+    }
+    else {
         CGRect rect = self.upperLeftContainerView.frame;
         rect.origin.y = 0.0f;
         self.upperLeftContainerView.frame = rect;
@@ -928,7 +939,8 @@ const static NSUInteger MMScrollIndicatorTag = 12345;
         rect = self.lowerLeftContainerView.frame;
         rect.origin.x = 0-scrollView.contentOffset.x;
         self.lowerLeftContainerView.frame = rect;
-    } else {
+    }
+    else {
         CGRect rect = self.upperLeftContainerView.frame;
         rect.origin.x = 0.0f;
         
@@ -941,7 +953,6 @@ const static NSUInteger MMScrollIndicatorTag = 12345;
 
 - (void)scrollViewWillBeginDragging:(UIScrollView *)scrollView
 {
-    NSLog(@"%s", __PRETTY_FUNCTION__);
     [self setScrollEnabledValue:NO scrollView:scrollView];
     
     if (self.controllingScrollView != scrollView) {
@@ -958,7 +969,6 @@ const static NSUInteger MMScrollIndicatorTag = 12345;
 
 - (void)scrollViewWillEndDragging:(UIScrollView *)scrollView withVelocity:(CGPoint)velocity targetContentOffset:(inout CGPoint *)targetContentOffset
 {
-    NSLog(@"%s VEL: %@", __PRETTY_FUNCTION__, NSStringFromCGPoint(velocity));
     // Block UI if we're in a bounce.
     // Without this, you can lock the scroll views in a scroll which looks weird.
     CGPoint toffset = *targetContentOffset;
@@ -967,7 +977,6 @@ const static NSUInteger MMScrollIndicatorTag = 12345;
             BOOL willBouncePastZeroY = velocity.y < 0.0f && !(toffset.y > 0.0f);
             BOOL willBouncePastMaxY = toffset.y > self.lowerLeftCollectionView.contentSize.height - self.lowerLeftCollectionView.frame.size.height - 0.1f && velocity.y > 0.0f;
             if (willBouncePastZeroY || willBouncePastMaxY || !self.bounces) {
-                NSLog(@"LL scroll: UP & LR lockout");
                 self.upperRightContainerView.userInteractionEnabled = NO;
                 self.lowerRightContainerView.userInteractionEnabled = NO;
                 self.lowerLeftBouncing = YES;
@@ -979,7 +988,6 @@ const static NSUInteger MMScrollIndicatorTag = 12345;
             BOOL willBouncePastZeroX = velocity.x < 0.0f && !(toffset.x > 0.0f);
             BOOL willBouncePastMaxX = toffset.x > self.upperRightCollectionView.contentSize.width - self.upperRightCollectionView.frame.size.width - 0.1f && velocity.x > 0.0f;
             if (willBouncePastZeroX || willBouncePastMaxX || !self.bounces) {
-                NSLog(@"UR scroll: LL & LR lockout");
                 self.lowerRightContainerView.userInteractionEnabled = NO;
                 self.lowerLeftContainerView.userInteractionEnabled = NO;
                 self.upperRightBouncing = YES;
@@ -994,7 +1002,6 @@ const static NSUInteger MMScrollIndicatorTag = 12345;
             BOOL willBouncePastMaxY = toffset.y > self.lowerLeftCollectionView.contentSize.height - self.lowerLeftCollectionView.frame.size.height - 0.1f && velocity.y > 0.0f;
             if (willBouncePastZeroX || willBouncePastMaxX ||
                 willBouncePastZeroY || willBouncePastMaxY || !self.bounces) {
-                NSLog(@"LR scroll: UR & LL lockout");
                 self.upperRightContainerView.userInteractionEnabled = NO;
                 self.lowerLeftContainerView.userInteractionEnabled = NO;
                 self.lowerRightBouncing = YES;
@@ -1011,7 +1018,6 @@ const static NSUInteger MMScrollIndicatorTag = 12345;
 
 - (void)scrollViewDidStop:(UIScrollView *)scrollView
 {
-    NSLog(@"%s", __PRETTY_FUNCTION__);
     self.upperRightContainerView.userInteractionEnabled = YES;
     self.lowerRightContainerView.userInteractionEnabled = YES;
     self.lowerLeftContainerView.userInteractionEnabled = YES;

--- a/MMSpreadsheetView/MMSpreadsheetView.m
+++ b/MMSpreadsheetView/MMSpreadsheetView.m
@@ -513,7 +513,11 @@ const static NSUInteger MMScrollIndicatorTag = 12345;
             if (indicatorHeight < MMSpreadsheetViewScrollIndicatorMinimum) {
                 indicatorHeight = MMSpreadsheetViewScrollIndicatorMinimum;
             }
-            CGFloat indicatorOffsetY = collectionView.contentOffset.y / (contentSize.height - collectionViewFrame.size.height) * (scrollIndicator.frame.size.height - indicatorHeight);
+            CGFloat divideByZeroOffset = 0.0f;
+            if (contentSize.height == collectionViewFrame.size.height) {
+                divideByZeroOffset = 1.0f;
+            }
+            CGFloat indicatorOffsetY = collectionView.contentOffset.y / (contentSize.height - collectionViewFrame.size.height + divideByZeroOffset) * (scrollIndicator.frame.size.height - indicatorHeight);
             indicatorView.frame = CGRectMake(0.0f,
                                              indicatorOffsetY,
                                              MMSpreadsheetViewScrollIndicatorWidth,
@@ -538,11 +542,11 @@ const static NSUInteger MMScrollIndicatorTag = 12345;
             if (indicatorWidth < MMSpreadsheetViewScrollIndicatorMinimum) {
                 indicatorWidth = MMSpreadsheetViewScrollIndicatorMinimum;
             }
-            CGFloat divZeroOffset = 0.0f;
+            CGFloat divideByZeroOffset = 0.0f;
             if (contentSize.width == collectionViewFrame.size.width) {
-                divZeroOffset = 1.0f;
+                divideByZeroOffset = 1.0f;
             }
-            CGFloat indicatorOffsetX = collectionView.contentOffset.x / (contentSize.width - collectionViewFrame.size.width + divZeroOffset) * (scrollIndicator.frame.size.width-indicatorWidth);
+            CGFloat indicatorOffsetX = collectionView.contentOffset.x / (contentSize.width - collectionViewFrame.size.width + divideByZeroOffset) * (scrollIndicator.frame.size.width-indicatorWidth);
             indicatorView.frame = CGRectMake(indicatorOffsetX,
                                              0.0f,
                                              indicatorWidth,

--- a/MMSpreadsheetView/NSIndexPath+MMSpreadsheetView.m
+++ b/MMSpreadsheetView/NSIndexPath+MMSpreadsheetView.m
@@ -22,11 +22,13 @@
 
 @implementation NSIndexPath (MMSpreadsheetView)
 
-- (NSInteger)mmSpreadsheetRow {
+- (NSInteger)mmSpreadsheetRow
+{
     return self.section;
 }
 
-- (NSInteger)mmSpreadsheetColumn {
+- (NSInteger)mmSpreadsheetColumn
+{
     return self.row;
 }
 


### PR DESCRIPTION
Fix divideByZero error if frame and content are exactly the same.

Reformats the files to new preferences.
Remove 64-bit warnings in the example app.
