### PR TITLE
Fix GitHub markdown flavour issue on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-#Mutual Mobile Spreadsheet View
+# Mutual Mobile Spreadsheet View
+
 `MMSpreadsheetView` is a configurable spreadsheet-like view. Depending on the initial header row or column configuration, up to four collection views will be coordinated to provide the user interface. Although originally designed for use on iPad in full-screen, it scales down well for use in smaller views.
 
 <p align="center" >
@@ -7,12 +8,14 @@
 
 ---
 
-##Documentation
+## Documentation
+
 Official appledoc documentation can be found at [CocoaDocs](http://cocoadocs.org/docsets/MMSpreadsheetView/).
 
 ---
 
-##Installing MMSpreadsheetView
+## Installing MMSpreadsheetView
+
 [![Badge w/ Version](https://cocoapod-badges.herokuapp.com/v/MMSpreadsheetView/badge.png)](https://cocoadocs.org/docsets/MMSpreadsheetView)
 [![Badge w/ Platform](https://cocoapod-badges.herokuapp.com/p/MMSpreadsheetView/badge.svg)](https://cocoadocs.org/docsets/MMSpreadsheetView)
 You can install MMSpreadsheetView in your project by using [CocoaPods](https://github.com/cocoapods/cocoapods):
@@ -23,7 +26,8 @@ pod 'MMSpreadsheetView', '~> 0.0.3'
 
 ---
 
-##Initializing a Spreadsheet View
+## Initializing a Spreadsheet View
+
 The designated initializer for `MMSpreadsheetView` requires passing in the number of header rows and columns as well as the initial bounds rect. Register the cell classes you will be using and set the delegate and dataSource. Finally, add the view as a subview.
 
 ```Objective-C
@@ -46,7 +50,7 @@ self.spreadSheetView = spreadSheetView;
 
 ---
 
-##Caveats
+## Caveats
 
 <ul>
 <li><strong>Performance</strong>: As the number of cells shown increases, scrolling performance declines. A large grid (1000x1000) takes a long time to initialize, but if the cell sizes are large enough (150x150) or greater, scrolling performance is not affected. However, a small grid (50x50) of (20x20) cells basically doesn't scroll.</li>
@@ -62,20 +66,23 @@ self.spreadSheetView = spreadSheetView;
 
 ---
 
-##Credit
+## Credit
+
 Designed and Developed by these fine folks at [Mutual Mobile](http://mutualmobile.com):
 
-###Development
+### Development
 
 * [Jeff Lacey](http://twitter.com/canispater)
 * [Kevin Harwood](http://twitter.com/kevinharwood)
 
 ---
 
-##Feedback
+## Feedback
+
 We'd love to hear feedback on the library. Create Github issues, or hit us up on Twitter.
 
 ---
 
-##License ![License MIT](https://go-shields.herokuapp.com/license-MIT-blue.png)
+## License ![License MIT](https://go-shields.herokuapp.com/license-MIT-blue.png)
+
 `MMSpreadsheetView` is available under the MIT license. See the LICENSE file for more info.


### PR DESCRIPTION
- GitHub has changed the rendering for the markdown. White space is added to the header tag. Refer to the [documentation Mastering Markdown](https://guides.github.com/features/mastering-markdown/)